### PR TITLE
Fix/21 dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,15 +73,14 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-
-    implementation("org.springframework.boot:spring-boot-starter-test") {
-        exclude(module = "junit")
-        exclude(module = "mockito-core")
-    }
     api("io.mockk:mockk:1.9.1")
 
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springframework.boot:spring-boot-test")
+    implementation("org.springframework:spring-test")
+
+    testImplementation("org.assertj:assertj-core")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     val kotlinVersion = "1.3.11"
 
-    java
+    `java-library`
     kotlin("jvm") version kotlinVersion
     `maven-publish`
     id("org.jetbrains.kotlin.plugin.spring") version kotlinVersion
@@ -80,7 +80,7 @@ dependencies {
         exclude(module = "junit")
         exclude(module = "mockito-core")
     }
-    implementation("io.mockk:mockk:1.9.1")
+    api("io.mockk:mockk:1.9.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")


### PR DESCRIPTION
@sdeleuze Could you have a look and test this PR?

You can clone the project, checkout the branch fix/21-dependencies, execute `./gradlew publishToMavenLocal`, and, in your own project, add `mavenLocal()` to your repositories and change the SpringMockK dependency version to 1.1.2-SNAPSHOT.

If it's OK, I'll make the 1.1.2 release ASAP.