### PR TITLE
fix: support confirmVerified

### DIFF
--- a/src/main/kotlin/com/ninjasquad/springmockk/MockkClear.kt
+++ b/src/main/kotlin/com/ninjasquad/springmockk/MockkClear.kt
@@ -1,6 +1,6 @@
 package com.ninjasquad.springmockk
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.IdentityHashMap
 
 /**
  * Clear strategy used on a mockk bean, applied to a mock via the
@@ -28,7 +28,10 @@ enum class MockkClear {
     NONE;
 
     companion object {
-        private val clearModesByMock = ConcurrentHashMap<Any, MockkClear>()
+        // this has to be an identity hash map. If it's a HashMap, then hashCode() is called on the mocks,
+        // and confirmVerified calls fail. See https://github.com/Ninja-Squad/springmockk/issues/27
+        // and see MockkClearIntegrationTests
+        private val clearModesByMock = IdentityHashMap<Any, MockkClear>()
 
         internal fun set(mock: Any, clear: MockkClear) {
             require(mock.isMock) { "Only mocks can be cleared" }

--- a/src/test/kotlin/com/ninjasquad/springmockk/MockkClearIntegrationTests.kt
+++ b/src/test/kotlin/com/ninjasquad/springmockk/MockkClearIntegrationTests.kt
@@ -1,0 +1,33 @@
+package com.ninjasquad.springmockk
+
+import com.ninjasquad.springmockk.example.ExampleService
+import com.ninjasquad.springmockk.example.ExampleServiceCaller
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+/**
+ * Integration test for [MockkClear]
+ * @author JB Nizet
+ */
+@ExtendWith(SpringExtension::class)
+class MockkClearIntegrationTests {
+    @MockkBean
+    private lateinit var exampleService: ExampleService
+
+    /**
+     * Test case for Issue #27. It fails if MockkClear uses a HashMap or a ConcurrentHashMap
+     * @see https://github.com/Ninja-Squad/springmockk/issues/27
+     */
+    @Test
+    fun test() {
+        val bean = ExampleServiceCaller(exampleService)
+        every { exampleService.greeting() } returns "test"
+        bean.sayGreeting()
+        verify { exampleService.greeting() }
+        confirmVerified(exampleService) // this is what fails when using a HashMap, because hashCode() is considered not verified
+    }
+}


### PR DESCRIPTION
Use an IdentityHashMap rather than a ConcurrentHashMap in MockkClear otherwise hashCode() is called and confirmVerified fails since the calls to hashCode() haven't been verified.

fix #27