### PR TITLE
fix: prevent from providing default mocks when relaxed are required and vice versa

### DIFF
--- a/src/main/kotlin/com/ninjasquad/springmockk/MockkDefinition.kt
+++ b/src/main/kotlin/com/ninjasquad/springmockk/MockkDefinition.kt
@@ -57,6 +57,8 @@ class MockkDefinition(
 
         if ((this.typeToMock as Any) != other.typeToMock) return false
         if (extraInterfaces != other.extraInterfaces) return false
+        if (relaxed != other.relaxed) return false
+        if (relaxUnitFun != other.relaxUnitFun) return false
 
         return true
     }
@@ -65,6 +67,8 @@ class MockkDefinition(
         var result = super.hashCode()
         result = MULTIPLER * result + typeToMock.hashCode()
         result = MULTIPLER * result + extraInterfaces.hashCode()
+        result = MULTIPLER * result + relaxed.hashCode()
+        result = MULTIPLER * result + relaxUnitFun.hashCode()
         return result
     }
 }


### PR DESCRIPTION
This PR fixes the bug shown here: https://github.com/wojteko22/springmockk-bug

