### PR TITLE
chore: publish the gradle module metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+build/
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class GreetingControllerTest {
 
 Add this to your dependencies:
 ```kotlin
-testImplementation("com.ninja-squad:springmockk:3.0.0")
+testImplementation("com.ninja-squad:springmockk:3.0.1")
 ```
 
 If you want to make sure Mockito (and the standard `MockBean` and `SpyBean` annotations) is not used, you can also exclude the mockito dependency:
@@ -59,7 +59,7 @@ Add this to your dependencies:
 <dependency>
   <groupId>com.ninja-squad</groupId>
   <artifactId>springmockk</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.squareup.okhttp3:okhttp:4.8.1")
+    implementation(gradleApi())
+}

--- a/buildSrc/src/main/kotlin/com/ninjasquad/gradle/MavenSyncTask.kt
+++ b/buildSrc/src/main/kotlin/com/ninjasquad/gradle/MavenSyncTask.kt
@@ -1,0 +1,65 @@
+package com.ninjasquad.gradle
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Credentials
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.IOException
+
+open class MavenSyncTask : DefaultTask() {
+    @Input
+    lateinit var sonatypeUsername: String
+
+    @Input
+    lateinit var sonatypePassword: String
+
+    @Input
+    lateinit var bintrayUsername: String
+
+    @Input
+    lateinit var bintrayPassword: String
+
+    @Input
+    lateinit var bintrayRepoName: String
+
+    @Input
+    lateinit var bintrayPackageName: String
+
+    @Input
+    var version = project.version.toString()
+
+    @TaskAction
+    fun sync() {
+        println("synchronizing with Maven central...")
+        val client = OkHttpClient()
+        val jsonBody =
+            // language=json
+            """
+            {
+              "username": "$sonatypeUsername",
+              "password": "$sonatypePassword",
+              "close": "1"
+            }
+            """.trimIndent()
+        val request: Request = Request.Builder()
+            .header("Authorization", Credentials.basic(bintrayUsername, bintrayPassword))
+            .url("https://api.bintray.com/maven_central_sync/$bintrayUsername/$bintrayRepoName/$bintrayPackageName/versions/$version")
+            .post(jsonBody.toRequestBody("application/json".toMediaType()))
+            .build()
+        try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw GradleException("Maven sync failed with status " + response.code + " and body " + response.body?.string())
+                }
+                println(response.body?.string())
+            }
+        } catch (e: IOException) {
+            throw GradleException("Maven sync failed", e)
+        }
+    }
+}


### PR DESCRIPTION
- avoid using the gradle bintray plugin, which doesn't upload the module metadata
- sign locally rather than with bintray
- publish the signed artefacts using the native maven-publish plugin
- use a custom task that uses the bintray API to sync with Maven Central

fix #56