### PR TITLE
Set README.md to latest published version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class GreetingControllerTest {
 
 Add this to your dependencies:
 ```kotlin
-testImplementation("com.ninja-squad:springmockk:3.0.2")
+testImplementation("com.ninja-squad:springmockk:3.0.1")
 ```
 
 If you want to make sure Mockito (and the standard `MockBean` and `SpyBean` annotations) is not used, you can also exclude the mockito dependency:
@@ -59,7 +59,7 @@ Add this to your dependencies:
 <dependency>
   <groupId>com.ninja-squad</groupId>
   <artifactId>springmockk</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.1</version>
   <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
I propose this change where by the README.md points to springmockk `3.0.1` which is the latest released and published version. I understand a commit was made to propare for the next version... I believe it's potentially misleading... Personally I've lost a few minutes today trying to figure out why my project couldn't download the dependency if I had followed the quickstart correctly.