### PR TITLE
fix: report fix "Allow beans with circular dependencies to be spied"

### DIFF
--- a/src/test/kotlin/com/ninjasquad/springmockk/SpyBeanOnTestFieldForExistingCircularBeansIntegrationTests.kt
+++ b/src/test/kotlin/com/ninjasquad/springmockk/SpyBeanOnTestFieldForExistingCircularBeansIntegrationTests.kt
@@ -1,0 +1,54 @@
+package com.ninjasquad.springmockk
+
+import com.ninjasquad.springmockk.SpyBeanOnTestFieldForExistingCircularBeansIntegrationTests.SpyBeanOnTestFieldForExistingCircularBeansConfig
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+
+/**
+ * Test [@SpykBean][SpykBean] on a test class field can be used to replace existing
+ * beans with circular dependencies.
+ *
+ * @author Andy Wilkinson
+ * @author JB Nizet
+ */
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [SpyBeanOnTestFieldForExistingCircularBeansConfig::class])
+internal class SpyBeanOnTestFieldForExistingCircularBeansIntegrationTests {
+    @SpykBean
+    private lateinit var one: One
+
+    @Autowired
+    private lateinit var two: Two
+
+    @Test
+    fun beanWithCircularDependenciesCanBeSpied() {
+        two.callOne()
+
+        verify { one.someMethod() }
+    }
+
+    @Import(One::class, Two::class)
+    internal class SpyBeanOnTestFieldForExistingCircularBeansConfig
+
+    internal class One {
+        @Autowired
+        private lateinit var two: Two
+
+        fun someMethod() {}
+    }
+
+    internal class Two {
+        @Autowired
+        private lateinit var one: One
+
+        fun callOne() {
+            one.someMethod()
+        }
+    }
+}


### PR DESCRIPTION
This reports the commit https://github.com/spring-projects/spring-boot/commit/9a3f05303456d2cfa626ddd42b558ca471cad6d2