### PR TITLE
Bump mockk version up to 1.13.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ dependencyManagement {
 }
 
 dependencies {
-    api("io.mockk:mockk:1.12.3")
+    api("io.mockk:mockk:1.13.2")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")


### PR DESCRIPTION
A new version of the library is released.

This is important due to some problems with JDK17. See: https://github.com/mockk/mockk/issues/832