### PR TITLE
fix: align behavior with Spring Boot when no bean name for spy found

### DIFF
--- a/src/main/kotlin/com/ninjasquad/springmockk/MockkPostProcessor.kt
+++ b/src/main/kotlin/com/ninjasquad/springmockk/MockkPostProcessor.kt
@@ -281,7 +281,9 @@ class MockkPostProcessor(private val definitions: Set<Definition>) : Instantiati
     ) {
         try {
             val beanName = determineBeanName(existingBeans, spykDefinition, registry)
-            registerSpy(spykDefinition, field, beanName!!)
+            beanName?.let {
+                registerSpy(spykDefinition, field, it)
+            }
         } catch (ex: RuntimeException) {
             throw IllegalStateException("Unable to register spy bean ${spykDefinition.typeToSpy}", ex)
         }


### PR DESCRIPTION
refs #100