### PR TITLE
Constructor parameter resolution

### DIFF
--- a/src/main/java/com/ninjasquad/springmockk/MockkBean.java
+++ b/src/main/java/com/ninjasquad/springmockk/MockkBean.java
@@ -72,7 +72,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author JB Nizet
  * @see MockkPostProcessor
  */
-@Target({ElementType.TYPE, ElementType.FIELD })
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Repeatable(MockkBeans.class)

--- a/src/main/java/com/ninjasquad/springmockk/SpykBean.java
+++ b/src/main/java/com/ninjasquad/springmockk/SpykBean.java
@@ -71,7 +71,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author JB Nizet
  * @see MockkPostProcessor
  */
-@Target({ ElementType.TYPE, ElementType.FIELD })
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Repeatable(SpykBeans.class)

--- a/src/main/kotlin/com/ninjasquad/springmockk/DefinitionsParser.kt
+++ b/src/main/kotlin/com/ninjasquad/springmockk/DefinitionsParser.kt
@@ -55,13 +55,13 @@ class DefinitionsParser(existing: Collection<Definition> = emptySet()) {
 
     private fun parseMockkBeanAnnotation(annotation: MockkBean, element: AnnotatedElement, source: Class<*>?) {
         val typesToMock = getOrDeduceTypes(element, annotation.value, source)
-        check(!typesToMock.isEmpty()) { "Unable to deduce type to mock from $element" }
+        check(typesToMock.isNotEmpty()) { "Unable to deduce type to mock from $element" }
         if (StringUtils.hasLength(annotation.name)) {
             check(typesToMock.size == 1) { "The name attribute can only be used when mocking a single class" }
         }
         for (typeToMock in typesToMock) {
             val definition = MockkDefinition(
-                name = if (annotation.name.isEmpty()) null else annotation.name,
+                name = annotation.name.ifEmpty { null },
                 typeToMock = typeToMock,
                 extraInterfaces = annotation.extraInterfaces,
                 clear = annotation.clear,
@@ -75,9 +75,7 @@ class DefinitionsParser(existing: Collection<Definition> = emptySet()) {
 
     private fun parseSpykBeanAnnotation(annotation: SpykBean, element: AnnotatedElement, source: Class<*>?) {
         val typesToSpy = getOrDeduceTypes(element, annotation.value, source)
-        Assert.state(
-            !typesToSpy.isEmpty()
-        ) { "Unable to deduce type to spy from $element" }
+        Assert.state(typesToSpy.isNotEmpty()) { "Unable to deduce type to spy from $element" }
         if (StringUtils.hasLength(annotation.name)) {
             Assert.state(
                 typesToSpy.size == 1,
@@ -86,7 +84,7 @@ class DefinitionsParser(existing: Collection<Definition> = emptySet()) {
         }
         for (typeToSpy in typesToSpy) {
             val definition = SpykDefinition(
-                name = if (annotation.name.isEmpty()) null else annotation.name,
+                name = annotation.name.ifEmpty { null },
                 typeToSpy = typeToSpy,
                 clear = annotation.clear,
                 qualifier = QualifierDefinition.forElement(element, source)
@@ -119,11 +117,10 @@ class DefinitionsParser(existing: Collection<Definition> = emptySet()) {
             types.add(ResolvableType.forClass(clazz.java))
         }
         if (types.isEmpty() && element is Field) {
-            val field = element
-            types.add(if (field.genericType is TypeVariable<*>) {
-                ResolvableType.forField(field, source!!)
+            types.add(if (element.genericType is TypeVariable<*>) {
+                ResolvableType.forField(element, source!!)
             } else {
-                ResolvableType.forField(field)
+                ResolvableType.forField(element)
             })
         }
         if (element is Parameter) {

--- a/src/main/kotlin/com/ninjasquad/springmockk/QualifierDefinition.kt
+++ b/src/main/kotlin/com/ninjasquad/springmockk/QualifierDefinition.kt
@@ -19,11 +19,7 @@ import java.lang.reflect.Parameter
  */
 class QualifierDefinition(private val field: Field, private val annotations: Set<Annotation>) {
 
-    private val descriptor: DependencyDescriptor
-
-    init {
-        this.descriptor = DependencyDescriptor(field, true)
-    }
+    private val descriptor = DependencyDescriptor(field, true)
 
     fun matches(beanFactory: ConfigurableListableBeanFactory, beanName: String): Boolean {
         return beanFactory.isAutowireCandidate(beanName, this.descriptor)

--- a/src/test/kotlin/com/ninjasquad/springmockk/DefinitionsParserTests.kt
+++ b/src/test/kotlin/com/ninjasquad/springmockk/DefinitionsParserTests.kt
@@ -288,7 +288,7 @@ class DefinitionsParserTests {
     @SpykBean(RealExampleService::class, ExampleServiceCaller::class)
     internal class SpyBeanMultipleClasses
 
-    @SpykBean(name = "name", classes = arrayOf(RealExampleService::class, ExampleServiceCaller::class))
+    @SpykBean(name = "name", classes = [RealExampleService::class, ExampleServiceCaller::class])
     internal class SpyBeanMultipleClassesWithName
 
     internal class SpyBeanInferClassToMock {

--- a/src/test/kotlin/com/ninjasquad/springmockk/DefinitionsParserTests.kt
+++ b/src/test/kotlin/com/ninjasquad/springmockk/DefinitionsParserTests.kt
@@ -66,7 +66,41 @@ class DefinitionsParserTests {
         val qualifier = QualifierDefinition.forElement(
             ReflectionUtils.findField(MockBeanOnClassAndField::class.java, "caller")!!
         )
-        assertThat(fieldDefinition.qualifier).isNotNull().isEqualTo(qualifier)
+        assertThat(fieldDefinition.qualifier).isNotNull.isEqualTo(qualifier)
+    }
+
+    @Test
+    fun parseMockBeanOnConstructorParameter() {
+        this.parser.parse(MockBeanInConstructor::class.java)
+        assertThat(definitions).hasSize(2)
+
+        val firstParameter = getMockDefinition(0)
+        assertThat(firstParameter.typeToMock.resolve()).isEqualTo(ExampleService::class.java)
+        assertThat(firstParameter.qualifier).isNull()
+
+        val secondParameter = getMockDefinition(1)
+        assertThat(secondParameter.typeToMock.resolve()).isEqualTo(ExampleServiceCaller::class.java)
+        val qualifier = QualifierDefinition.forElement(
+            ReflectionUtils.findField(MockBeanOnClassAndField::class.java, "caller")!!
+        )
+        assertThat(secondParameter.qualifier).isNotNull().isEqualTo(qualifier)
+    }
+
+    @Test
+    fun parseMockBeanOnConstructorParameterViaField() {
+        this.parser.parse(MockBeanInConstructorViaField::class.java)
+        assertThat(definitions).hasSize(2)
+
+        val firstParameter = getMockDefinition(0)
+        assertThat(firstParameter.typeToMock.resolve()).isEqualTo(ExampleService::class.java)
+        assertThat(firstParameter.qualifier).isNull()
+
+        val secondParameter = getMockDefinition(1)
+        assertThat(secondParameter.typeToMock.resolve()).isEqualTo(ExampleServiceCaller::class.java)
+        val qualifier = QualifierDefinition.forElement(
+            ReflectionUtils.findField(MockBeanOnClassAndField::class.java, "caller")!!
+        )
+        assertThat(secondParameter.qualifier).isNotNull().isEqualTo(qualifier)
     }
 
     @Test
@@ -206,6 +240,16 @@ class DefinitionsParserTests {
         private val caller: Any? = null
 
     }
+
+    internal class MockBeanInConstructor(
+        @MockkBean private val exampleService: ExampleService,
+        @MockkBean @Qualifier("test") val caller: ExampleServiceCaller,
+    )
+
+    internal class MockBeanInConstructorViaField(
+        @field:MockkBean private val exampleService: ExampleService,
+        @field:MockkBean @field:Qualifier("test") val caller: ExampleServiceCaller,
+    )
 
     @MockkBean(ExampleService::class, ExampleServiceCaller::class)
     internal class MockBeanMultipleClasses


### PR DESCRIPTION
Hello

I implemented idea in https://github.com/Ninja-Squad/springmockk/issues/104.

What I did:
* added parameter target to annotation so mock annotations can be used on constructor parameters
* I changed parser to accept both fields and constructor parameters
* Spring dependency descriptor still requires field in order to work hence I try to map constructor param to field by type (constructor param names are cleared at the bytecode) - in other words, we read annotations from ctor param but under hood we use backing-field for actual binding, it will work as long there is 1:1 mapping, otherwise we ignore it (just as it is now)
* added tests
* fixed Intellij warnings

I already tested snapshot version locally, here's is a repository with example code:
https://github.com/kkurczewski/spring-mockk-constructor-injection

In this repository I also implemented [`SpringMockkExtension`](https://github.com/kkurczewski/spring-mockk-constructor-injection/blob/master/mockkbean-junit5-extension/src/main/kotlin/com/example/MockKBeanExtension.kt) for JUnit5, it just barely one class but without it parameter resolver will throw errors.

This extension depends both on SpringMockk and Junit5 code, as original springmockk artifact doesn't bundle Junit5 extension this probably should be released as a separate artifact but maybe this is an overkill, not sure.