### PR TITLE
Upgrade to MockK veresion 1.13.9 + Misc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class GreetingControllerTest {
 
 Add this to your dependencies:
 ```kotlin
-testImplementation("com.ninja-squad:springmockk:4.0.2")
+testImplementation("com.ninja-squad:springmockk:4.0.3")
 ```
 
 If you want to make sure Mockito (and the standard `MockBean` and `SpyBean` annotations) is not used, you can also exclude the mockito dependency:
@@ -59,7 +59,7 @@ Add this to your dependencies:
 <dependency>
   <groupId>com.ninja-squad</groupId>
   <artifactId>springmockk</artifactId>
-  <version>4.0.2</version>
+  <version>4.0.3</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -107,10 +107,12 @@ For Maven users:
 ````
 
 ## Limitations
+
  - the [issue 5837](https://github.com/spring-projects/spring-boot/issues/5837), which has been fixed for Mockito spies using Mockito-specific features, also exists with MockK, and hasn't been fixed yet. 
    If you have a good idea, please tell!
- - [this is not an official Spring Boot project](https://github.com/spring-projects/spring-boot/issues/15749), so it might not work out of the box for newest versions if backwards incompatible changes are introduced in Spring Boot. 
- Please file issues if you find problems.
+ - [this is not an official Spring Boot project](https://github.com/spring-projects/spring-boot/issues/15749),
+   so it might not work out of the box for newest versions if backwards incompatible changes are introduced in Spring Boot. 
+   Please file issues if you find problems.
  - annotations are looked up on fields, and not on properties (for now). 
    This doesn't matter much until you use a custom qualifier annotation.
    In that case, make sure that it targets fields and not properties, or use `@field:YourQualifier` to apply it on your beans.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "com.ninja-squad"
-version = "4.0.2"
+version = "4.0.3"
 description = "MockBean and SpyBean, but for MockK instead of Mockito"
 
 val sonatypeUsername = project.findProperty("sonatypeUsername")?.toString() ?: ""

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.Duration
 
 plugins {
-    // if it's changed, it must also be channged in the bomProperty below
+    // if it's changed, it must also be changed in the bomProperty below
     val kotlinVersion = "1.7.21"
 
     `java-library`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,7 @@ dependencyManagement {
 }
 
 dependencies {
-    api("io.mockk:mockk-jvm:1.13.3")
+    api("io.mockk:mockk-jvm:1.13.9")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-test")


### PR DESCRIPTION
MockK has been updated to `1.13.9`, and I thought it was pretty decent timing to bring that version to springmockk as the latest version of MockK has many good patches and improvements including:

* https://github.com/mockk/mockk/pull/1002
* https://github.com/mockk/mockk/pull/1032
* https://github.com/mockk/mockk/pull/1052 -> especially important to me
* https://github.com/mockk/mockk/pull/1109
* https://github.com/mockk/mockk/pull/1117
* https://github.com/mockk/mockk/pull/1145
* https://github.com/mockk/mockk/pull/1149
* https://github.com/mockk/mockk/pull/1148
* https://github.com/mockk/mockk/pull/1154
* https://github.com/mockk/mockk/pull/1143
* https://github.com/mockk/mockk/pull/1164
* https://github.com/mockk/mockk/pull/1163
* https://github.com/mockk/mockk/pull/1184
* https://github.com/mockk/mockk/pull/1176
* https://github.com/mockk/mockk/pull/1195

This includes polishing documents and preparing a new release version of springmockk as well.